### PR TITLE
ci: fix BoardYml encoding error on Windows

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -335,7 +335,11 @@ class BoardYmlCheck(ComplianceTest):
 
     def check_board_file(self, file, vendor_prefixes):
         """Validate a single board file."""
-        with open(file) as fp:
+        # Use explicit UTF-8 decoding: Windows default locale (e.g. cp936/gbk) may
+        # choke on valid UTF-8 bytes in board.yml (triggering UnicodeDecodeError
+        # seen in compliance run). Other parts of this script already open YAML
+        # with encoding='utf-8', so keep it consistent here.
+        with open(file, encoding='utf-8') as fp:
             for line_num, line in enumerate(fp.readlines(), start=1):
                 if "vendor:" in line:
                     _, vnd = line.strip().split(":", 2)


### PR DESCRIPTION
## Summer
Force UTF-8 encoding when reading board.yml files in check_compliance.py, avoiding UnicodeDecodeError caused by Windows default GBK locale. This ensures BoardYml compliance checks work correctly on all platforms.